### PR TITLE
htmlparser/xmltree: since is now in std/private/since

### DIFF
--- a/src/fusion/htmlparser/xmltree.nim
+++ b/src/fusion/htmlparser/xmltree.nim
@@ -36,6 +36,7 @@
 
 import macros, strtabs, strutils
 include "system/inclrtl"
+import std/private/since
 
 type
   XmlNode* = ref XmlNodeObj ## An XML tree consisting of XML nodes.


### PR DESCRIPTION
This is breaking docgen for new nightlies.