### PR TITLE
Add `enummaps` module to attach metadata to enums; as a special case, it replaces enum with holes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,3 +3,5 @@
 - Added module `pointers` containing `toUncheckedArray`.
 - Added `filepermissions.chmod` and `filepermissions.fromFilePermissions`,
   convenience functions to change file permissions using Unix like octal file permissions.
+- Added module `pointers` containing `toUncheckedArray`
+- Add `enummaps` module which enables a DRY and flexible syntax to attach metadata to enums.

--- a/src/fusion/enummaps.nim
+++ b/src/fusion/enummaps.nim
@@ -9,7 +9,7 @@ Note: experimental module, unstable API
 
 #[
 ## TODO
-* pending https://github.com/nim-lang/RFCs/issues/150 or https://github.com/nim-lang/Nim/pull/8903,
+* pending https://github.com/nim-lang/RFCs/issues/150 or https://github.com/nim-lang/Nim/pull/8903
 reattach doc comments to enum members (+ show enummap attached values)
 
 * pending #13830, you'll be able to write instead:

--- a/src/fusion/enummaps.nim
+++ b/src/fusion/enummaps.nim
@@ -29,7 +29,7 @@ const nimHasArrayEnumIndex = compiles(block:
   # for bootstrap; remove pending csources2 https://github.com/timotheecour/Nim/issues/251
 
 runnableExamples:
-  ## See `tests/stdlib/tenummaps.nim` for more examples.
+  ## See `tests/tenummaps.nim` for more examples.
   enumMap:
     type MyHoly = enum
       kDefault = -1 ## sentinel, when reverse lookup fails in `byVal`

--- a/src/fusion/enummaps.nim
+++ b/src/fusion/enummaps.nim
@@ -1,8 +1,7 @@
 ##[
 This module implements enum maps, which are syntax sugar for compiletime or runtime
-mapping from enum members to a value type. This can be used as a type safe
-generalization of enum with holes, or any application where you have a
-collection of values.
+mapping from enum members to a value type. Enummaps can be used as a type safe
+generalization of enum with holes.
 
 Note: experimental module, unstable API
 ]##

--- a/src/fusion/enummaps.nim
+++ b/src/fusion/enummaps.nim
@@ -1,0 +1,163 @@
+##[
+This module implements enum maps, which are syntax sugar for compiletime or runtime
+mapping from enum members to a value type. This can be used as a type safe
+generalization of enum with holes, or any application where you have a
+collection of values.
+
+Note: experimental module, unstable API
+]##
+
+#[
+## TODO
+* pending https://github.com/nim-lang/RFCs/issues/150 or https://github.com/nim-lang/Nim/pull/8903,
+reattach doc comments to enum members (+ show enummap attached values)
+
+* pending #13830, you'll be able to write instead:
+```nim
+  type MyHoly {.enumMap.} = enum
+    k1 = 1
+    k2 = 4
+```
+so docs for this will need to be updated
+]#
+
+import macros
+
+const nimHasArrayEnumIndex = compiles(block:
+  type Foo = enum foo0
+  discard [foo0: 0][foo0])
+  # for bootstrap; remove pending csources2 https://github.com/timotheecour/Nim/issues/251
+
+runnableExamples:
+  ## See `tests/stdlib/tenummaps.nim` for more examples.
+  enumMap:
+    type MyHoly = enum
+      kDefault = -1 ## sentinel, when reverse lookup fails in `byVal`
+      k1 = 1 ##
+      k2 = 4 ## hole
+      k3 = 1 ## repeated and out of order is ok
+  doAssert k2.ord == 2
+  doAssert k2.val == 4
+  doAssert k2 == MyHoly.k2
+  static: doAssert MyHoly.byVal(4) == k2 # works at CT
+  doAssert MyHoly.byVal(1) == k1 # finds 1st occurrence
+  doAssert MyHoly.byVal(17) == kDefault # catch-all, can be used
+
+  ## Any value type is valid:
+  enumMap:
+    type Color = enum
+      cDefault = (ansi: 0, name: "normal", hex: "", rgb: [0'u8,0,0]) ## default
+      cBlack = (30, "black", "#000000", [0'u8,0,0]) ## black
+      cGreen = (32, "green", "#008000", [0'u8,128,0]) ## green
+      cDarkolivegreen = (32, "dark olive green", "#556B2F", [85'u8, 107, 47]) ## red
+  static:
+    doAssert cBlack.val.name == "black"
+    doAssert Color.findByIt(it.val.name == "green") == cGreen
+
+  ## runtime values are possible:
+  var myval = 10
+  enumMapCustom(valKind="var"):
+    type Foo = enum
+      k0 = myval
+  doAssert k0.val == myval
+  k0.val = 11
+  doAssert k0.val == 11
+
+proc lastSon(n: NimNode): NimNode =
+  if n.len == 0: n
+  else: n[^1]
+
+proc maybeExport(n: NimNode, doExport: bool): NimNode =
+  if doExport: newTree(nnkPostfix, ident"*", n)
+  else: n
+
+proc enumMapImpl(valKind: string, body: NimNode): NimNode =
+  ## builds an enum with a map enum => val, allowing library implementation
+  ## of enum with holes. This lifts restrictions on enum values, so that
+  ## arbitrary types can be used as values, including non ordinal, repeated, or
+  ## out of order values.
+  var body = body
+  doAssert body.kind == nnkStmtList and body.len == 1
+  body = body[0]
+  doAssert body.kind == nnkTypeSection and body.len == 1
+  let body2 = copyNimTree(body)
+  let isExported = body[0][0].kind == nnkPostfix and body[0][0][0].strVal == "*"
+  let name = body[0][0].lastSon
+
+  let v = nnkBracket.newTree()
+  let elems = body2[0][2]
+  for i, ai in elems:
+    if i>0:
+      elems[i] = ai[0]
+      v.add newTree(nnkExprColonExpr, elems[i], ai[^1])
+      # this won't work: v.add newCommentStmtNode "..."
+  let vals = ident"vals".maybeExport(isExported)
+  let val = ident"val".maybeExport(isExported)
+
+  result = newStmtList()
+  result.add body2
+
+  var varr: NimNode
+  case valKind
+  of "let":
+    varr = genSym(nskLet, "varr")
+    result.add quote do:
+      let `varr` = `v`
+  of "var":
+    varr = genSym(nskVar, "varr")
+    result.add quote do:
+      var `varr` = `v`
+  of "const":
+    varr = genSym(nskConst, "varr")
+    result.add quote do:
+      const `varr` = `v`
+  else: error("invalid valKind: " & valKind)
+
+  result.add quote do:
+    template `vals`(t: type `name`): untyped = `varr`
+  if nimHasArrayEnumIndex:
+    result.add quote do:
+      template `val`(a: `name`): untyped = `varr`[a]
+  else:
+    result.add quote do:
+      template `val`(a: `name`): untyped = `varr`[a.ord]
+
+  if valKind == "var":
+    let val2 = newTree(nnkAccQuoted, ident"val", ident"=").maybeExport(isExported)
+    result.add quote do:
+      template `val2`(a: `name`, b) = `varr`[a] = b
+
+macro enumMap*(body: untyped): untyped =
+  result = enumMapImpl(valKind = "const", body)
+
+macro enumMapCustom*(valKind: static string, body: untyped): untyped =
+  # pending #14346, merge with `enumMap`
+  result = enumMapImpl(valKind = valKind, body)
+
+when false:
+  # broken pending https://github.com/nim-lang/Nim/issues/13747
+  # so we use an auxiliary template as workaround
+  proc byValImpl[V](a: V, T: typedesc): T =
+    mixin vals
+    for ai in T:
+      if T.vals[ai] == a: return ai
+
+proc byValImpl[V](a: V, T: typedesc, vals: array): T =
+  ## can be optimized in different ways if ever needed, eg building a trie
+  ## at CT, followed by trie search at RT. Other option is a hash table
+  for ai in T:
+    if vals[ai] == a: return ai
+
+template byVal*(E: typedesc[enum], a: typed): E =
+  ## reverse lookup by value
+  byValImpl(a, E, E.vals)
+
+template findByIt*(E: typedesc[enum], pred: untyped): E =
+  ## reverse lookup by a predicate `pred` on `it`
+  var ret: E
+  block outer:
+    for it {.inject.} in E:
+      if pred:
+        ret = it
+        break outer
+  ret

--- a/tests/menummaps.nim
+++ b/tests/menummaps.nim
@@ -1,0 +1,8 @@
+import std/enummaps
+
+enumMap:
+  type Foo* = enum
+    fDefault = ""
+    f1 = "foo1"
+    f2 = "foo2"
+    f3 = "foo3"

--- a/tests/menummaps.nim
+++ b/tests/menummaps.nim
@@ -1,4 +1,4 @@
-import std/enummaps
+import fusion/enummaps
 
 enumMap:
   type Foo* = enum

--- a/tests/tenummaps.nim
+++ b/tests/tenummaps.nim
@@ -1,4 +1,4 @@
-import std/enummaps
+import fusion/enummaps
 from sequtils import toSeq
 
 template isDefault[T](a: T): bool = a == default(type(a))

--- a/tests/tenummaps.nim
+++ b/tests/tenummaps.nim
@@ -1,0 +1,205 @@
+import std/enummaps
+from sequtils import toSeq
+
+template isDefault[T](a: T): bool = a == default(type(a))
+
+when false:
+  # the current design of macro pragmas makes the following hard or impossible
+  # but the following syntax will be possible pending https://github.com/nim-lang/Nim/issues/13830
+  type MyHoly {.enumMap.} = enum
+    k1 = 1
+    k2 = 4
+
+block:
+  enumMap:
+    type MyHoly = enum
+      k1 = 1
+      k2 = 4 ## some comment
+      k3 = 1 # repeated and out of order is ok
+
+  doAssert k1.ord == 0
+  doAssert k1.val == 1
+  static:
+    doAssert k2.ord == 1
+    doAssert k2.val == 4
+  doAssert k2 == MyHoly.k2
+  for ai in MyHoly: discard
+  doAssert toSeq(MyHoly) == @[k1, k2, k3]
+
+  block: # https://github.com/nim-lang/Nim/issues/13980
+    proc fun(e: MyHoly): int =
+      case e
+      of k1: 1
+      of k2: 2
+      of k3: 3
+    doAssert k2.fun == 2
+
+  doAssert MyHoly.default.val.type is int
+
+  doAssert MyHoly.byVal(4) == k2
+  doAssert MyHoly.byVal(1) == k1 # finds 1st occurrence
+  doAssert MyHoly.vals == [1,4,1]
+
+block:
+  # example that could be used in compiler code
+  block: # simplest apporach: val = string
+    enumMap:
+      type TCallingConvention2 = enum
+        ccDefault = ""   # proc has no explicit calling convention
+        ccStdCall  = "stdcall" # procedure is stdcall
+
+    template name(a: TCallingConvention2): string = a.val
+    doAssert $ccStdCall == "ccStdCall"
+    doAssert ccStdCall.val == "stdcall"
+    doAssert ccStdCall.name == "stdcall"
+
+  block:
+    # more future proof approach: val = tuple[name: string]
+    # this allows adding fields without beaking client code
+    enumMap:
+      type TCallingConvention2 = enum
+        ccDefault = (name: "", doc: "proc has no explicit calling convention")
+        ccStdCall  = ("stdcall", "procedure is stdcall")
+
+    template name(a: TCallingConvention2): string = a.val.name
+    doAssert $ccStdCall == "ccStdCall"
+    doAssert ccStdCall.val.name == "stdcall"
+    doAssert ccStdCall.name == "stdcall"
+
+block:
+  enumMap:
+    type MyHoly2 = enum
+      k1 = (1.3, 'x', @[10]) # any type is ok
+      k2 = (1.0, 'y', @[])
+
+  template fun() =
+    doAssert k1.ord == 0
+    doAssert k1.val == (1.3, 'x', @[10])
+    doAssert k1.val == (1.3, 'x', @[10])
+    doAssert $k1 == "k1"
+
+  static: fun()
+  fun()
+
+  # checks that we can't mutate values
+  doAssert not compiles(k1.val[0] = 5.2)
+
+block: # test valKind
+  type Bar = object
+    name: string
+  enumMap:
+    type Foo = enum
+      k0 = Bar()
+      k1 = Bar(name: "myk1")
+  doAssert k1.val == Bar(name: "myk1")
+
+block: # test valKind
+  var myval = 3
+  enumMapCustom(valKind="var"):
+    type Foo = enum
+      k0 = (0,)
+      k1 = (myval*2,)
+      k2 = (2,)
+  doAssert k1.ord == 1
+  doAssert k1.val[0] == myval*2
+  k1.val[0] = -3
+  doAssert k1.val[0] == -3
+  k1.val = (-4,)
+  doAssert k1.val == (-4,)
+
+block: # shows we can use a CT map defined by some function
+  var count {.compileTime.}: int
+  proc fun(): int =
+    result = count
+    count+=2
+
+  enumMap:
+    type Foo = enum
+      k0 = fun()
+      k1 = fun()
+      k2 = fun()
+  doAssert Foo.vals.static == [0,2,4]
+
+import menummaps
+
+block:
+  # test import
+  doAssert Foo.f1 == f1
+  doAssert f2.val == "foo2"
+
+  # test lookup
+  doAssert Foo.byVal("foo3") == f3
+  doAssert Foo.byVal("nonexistant").isDefault
+  doAssert Foo.byVal("nonexistant2").isDefault
+
+block:
+  # example: cmdline application; this minimizes boilerplate and eliminates
+  # code duplication of cmd names, and allows help messages to access command
+  # names + doc strings
+  enumMap:
+    type Cmd = enum
+      kDefault = (name: "", doc: "")
+      kRun = ("run", "perform a run")
+      kJump = ("jump", "this will do a jump")
+      kHelp = ("help", "print cmdline usage")
+      kHelpAlt = ("h", "ditto")
+
+  proc help(): string =
+    ## no code duplication: the strings (and doc msgs) appear only once
+    result = "cmdline usage:\n"
+    for ai in Cmd:
+      if ai == Cmd.default: continue
+      result.add "  " & ai.val[0] & ": " & ai.val[1] & "\n"
+
+  proc process(cmd: string): int =
+    let key = Cmd.findByIt(it.val.name == cmd)
+    case key
+    of kDefault: 0
+    of kRun: 1
+    of kJump: 2
+    of kHelp, kHelpAlt: (if false: echo help(); 2)
+
+  doAssert "run".process == 1
+  doAssert "h".process == 2
+  doAssert "nonexistant".process == 0
+
+when true:
+  # example showing we can define an `OrderedEnum` type class for enums
+  # with a strict ordering
+  proc isOrderedEnum(a: typedesc[enum]): bool =
+    mixin val
+    when compiles(a.default.val):
+      var ret = a.default.val
+      var first = true
+      for ai in a:
+        if first: first = false
+        elif ai.val <= ret: return false
+        else: ret = ai.val
+    return true
+
+  enumMap:
+    type MyHoly1 = enum
+      k1 = 1
+      k2 = 4
+      k3 = 4
+  enumMap:
+    type MyHoly2 = enum
+      g1 = 1
+      g2 = 4
+      g3 = 5
+  static:
+    doAssert not MyHoly1.isOrderedEnum
+    doAssert MyHoly2.isOrderedEnum
+
+  type OrderedEnum = concept a
+    isOrderedEnum(a.type)
+  proc fun2(a: OrderedEnum) = discard
+  doAssert not compiles(fun2(k1))
+  doAssert compiles(fun2(g1))
+  doAssert MyHoly1 isnot OrderedEnum
+  doAssert MyHoly2 is OrderedEnum
+
+  when false:
+    # pending https://github.com/nim-lang/Nim/pull/12048
+    # we'll be allowed to use:
+    proc fun(a: T) {.enableif: isOrderedEnum(T).} = discard


### PR DESCRIPTION
Add `enummaps` module which enables a DRY and flexible syntax to attach metadata to enums; it also avoids need for enum with holes

* migrated from https://github.com/nim-lang/Nim/pull/14008, minus the compiler changes which were showcasing how compiler could take advantage of enummaps 
* pending https://github.com/nim-lang/fusion/issues/22, compiler could use fusion/enummaps and the compiler changes from https://github.com/nim-lang/Nim/pull/14008 could be done too
* see https://github.com/nim-lang/Nim/pull/14008 for examples and discussion
/cc @araq please squash and rebase instead of merge to avoid merge commits for consistency with nim repo, the past few PR's have merge commits :-)
