### PR TITLE
CI: run docs, publish docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,3 +181,23 @@ jobs:
         run: |
           cd fusion
           nimble test
+
+      - name: docs
+        run: |
+          cd fusion
+          nimble docs
+
+      - name: Deploy docs
+        # to view docs on your own fork: push a gh-pages branch on your fork,
+        # enable gh-pages in your fork
+        # and remove `github.ref == 'refs/heads/master'` below
+        if: |
+          github.event_name == 'push' && github.ref == 'refs/heads/master' &&
+          matrix.target.os == 'linux' && matrix.target.cpu == 'amd64' &&
+          matrix.branch == 'devel'
+        uses: crazy-max/ghaction-github-pages@v1
+        with:
+          build_dir: fusion/htmldocs
+          target_branch: gh-pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,7 @@ jobs:
           nimble test
 
       - name: docs
+        if: matrix.branch == 'devel'
         run: |
           cd fusion
           nimble docs

--- a/fusion.nimble
+++ b/fusion.nimble
@@ -13,4 +13,4 @@ requires "nim >= 1.0.0"
 task docs, "":
   # can customize, eg: 
   # exec "nim r src/fusion/docutils " & srcDir & " --outdir:htmldocs2 -d:foo"
-  exec "nim r src/fusion/docutils " & srcDir
+  exec "nim c -r src/fusion/docutils " & srcDir

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,5 @@
 # Nim Fusion
+docs: https://nim-lang.github.io/fusion/theindex.html
 
 Fusion contains Nim modules that are to be bundled with the Nim installation in order to give us something like the "Nim distribution". 
 Fusion fullfills multiple purposes: 


### PR DESCRIPTION
## TODO in future work
* make sure some index.html exists so we can point directly to https://nim-lang.github.io/fusion instead of https://nim-lang.github.io/fusion/theindex.html
* link to https://nim-lang.github.io/fusion from nim repo
