### PR TITLE
Fix issue #43: `min` example for fusion/astdsl.nim is wrong

### DIFF
--- a/src/fusion/astdsl.nim
+++ b/src/fusion/astdsl.nim
@@ -102,13 +102,13 @@ macro buildAst*(node, children: untyped): NimNode =
         let tmp = genSym(nskVar, "minResult")
         expectMinLen(args, 1)
         newVarStmt(tmp, args[0])
-        ifStmt:
-          for i in 1..<args.len:
+        for i in 1..<args.len:
+          ifStmt:
             elifBranch(infix(ident"<", args[i], tmp)):
               asgn(tmp, args[i])
         tmp
 
-    assert min("a", "b", "c", "d") == "a"
+    assert min("d", "c", "b", "a") == "a"
 
   let kids = newProc(procType=nnkDo, body=children)
   expectKind kids, nnkDo


### PR DESCRIPTION
Apparently, fixing #43 is easy. Using a sequence of straight `if` statements to find a `min`. 

Code generated from `min("d", "c", "b", "a")` macro call now looks as follows:
```Nim
var minResult_14505010 = "d"
if "c" < minResult_14505010:
  minResult_14505010 = "c"
if "b" < minResult_14505010:
  minResult_14505010 = "b"
if "a" < minResult_14505010:
  minResult_14505010 = "a"
minResult_14505010
```