### PR TITLE
Improve filepermissions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,3 +7,4 @@
   convenience functions to change file permissions using Unix like octal file permissions.
 - Added module `scripting` providing `withDir` to switch the directory temporarily. This
   was previously only available in the `nimscript` module.
+- Added `openArray[char]` overloads for `filepermissions.chmod` and `filepermissions.toFilePermissions`.


### PR DESCRIPTION
- Added `openArray[char]` overloads for `filepermissions.chmod` and `filepermissions.toFilePermissions`.
- Continues the work done:
  - https://github.com/nim-lang/Nim/pull/14866#issuecomment-653793524 
  - https://github.com/nim-lang/fusion/pull/13
  - https://github.com/nim-lang/fusion/pull/17 
  - This was requested on previous pull requests.

```nim
chmod("example.txt", "rw-r--r--")
chmod("example.txt", "rwxrwxrwx")
```

(I tried to use a `for` loop and gives same metrics as the `if`'s so I went with the simpler code)
