### PR TITLE
fix regression caused by caseStmtMacros: match=>case

### DIFF
--- a/src/fusion/matching.nim
+++ b/src/fusion/matching.nim
@@ -2109,7 +2109,7 @@ func toNode(
 
 macro expand*(body: typed): untyped = body
 
-macro match*(n: untyped): untyped =
+proc matchImpl(n: NimNode): NimNode =
   var matchcase = nnkIfStmt.newTree()
   var mixidents: seq[string]
   for elem in n[1 .. ^1]:
@@ -2157,7 +2157,10 @@ macro match*(n: untyped): untyped =
       let pos {.inject, used.}: int = 0
       `matchcase`
 
-  # echo result.repr
+when (NimMajor, NimMinor, NimPatch) >= (1,5,1):
+  macro `case`*(n: untyped): untyped = matchImpl(n)
+else:
+  macro match*(n: untyped): untyped = matchImpl(n)
 
 macro assertMatch*(input, pattern: untyped): untyped =
   ## Try to match `input` using `pattern` and raise `MatchError` on


### PR DESCRIPTION
this should fix the recent regression caused by https://github.com/nim-lang/Nim/pull/16923 and unblock fusion in important_packages, refs https://github.com/nim-lang/Nim/pull/17094

but after this PR we should fix `caseStmtMacros` to be implemented as `macro customCase[T](a: T, b: CaseStmt): untyped = ...`, as described in https://github.com/nim-lang/RFCs/issues/332#issuecomment-778433560
