### PR TITLE
Fix #76, #82, #83, update docs, more constistent `opt <pattern> or <default>` implementation

### DIFF
--- a/src/fusion/matching.nim
+++ b/src/fusion/matching.nim
@@ -42,7 +42,7 @@ const
     ## identifiers)
 
 
-const debugWIP = true
+const debugWIP = false
 
 template echov(arg: untyped, indent: int = 0): untyped {.used.} =
   {.noSideEffect.}:
@@ -2218,11 +2218,12 @@ func makeMatchExpr(
             bindVar = newLit(true)
 
           result = quote do:
-            let it {.inject.} = `parent`
-            if `pred`:
-              `bindVar`
-            else:
-              false
+            block:
+              let it {.inject.} = `parent`
+              if `pred`:
+                `bindVar`
+              else:
+                false
 
     of kSeq:
       return makeSeqMatch(

--- a/src/fusion/matching.nim
+++ b/src/fusion/matching.nim
@@ -163,9 +163,10 @@ func firstDot(n: NimNode): NimNode {.inline.} =
   splitDots(n)[0]
 
 template assertKind(node: NimNode, kindSet: set[NimNodeKind]): untyped =
-  if node.kind notin kindSet:
-    raiseAssert("Expected one of " & $kindSet & " but node has kind " &
-      $node.kind & " (assertion on " & $instantiationInfo() & ")")
+  {.line: instantiationInfo(fullpaths = true).}:
+    if node.kind notin kindSet:
+      raiseAssert("Expected one of " & $kindSet & " but node has kind " &
+        $node.kind & " (assertion on " & $instantiationInfo() & ")")
 
 func startsWith(n: NimNode, str: string): bool =
   n.nodeStr().startsWith(str)

--- a/src/fusion/matching.nim
+++ b/src/fusion/matching.nim
@@ -1658,17 +1658,16 @@ proc makeElemMatch(
           {.line: `ln`.}:
             raise MatchError(msg: `str` & $(`posid` - 1) & " failed")
 
+      var varset = newStmtList()
       if elem.bindVar.getSome(bindv):
         result.body.add newCommentStmtNode(
           "Set variable " & bindv.nodeStr() & " " &
             $vtable[bindv.nodeStr()].varKind)
 
-
         let vars = makeVarSet(
           bindv, parent.toAccs(mainExpr, false), vtable, doRaise)
 
-
-        result.body.add quote do:
+        varset.add quote do:
           if not `vars`:
             `failBreak`
 
@@ -1676,19 +1675,18 @@ proc makeElemMatch(
          elem.pattern.itemMatch == imkInfixEq and
          elem.pattern.isPlaceholder:
         result.body.add quote do:
+          `varSet`
           inc `counter`
           inc `posid`
           continue
       else:
         result.body.add quote do:
           if `expr`:
-            # debugecho "Match ok"
             inc `counter`
             inc `posid`
             continue
 
           else:
-            # debugecho "Fail break"
             `failBreak`
 
     else:

--- a/src/fusion/matching.nim
+++ b/src/fusion/matching.nim
@@ -1590,9 +1590,6 @@ func makeVarTable(m: Match):
 
           correctPathForOptionalField(sub, vt, pattern, path)
 
-          # echov path.mapIt($it), path.len
-
-
         if sub.seqMatches.getSome(seqm):
           result &= aux(seqm, vt, path.fullCopy())
 

--- a/src/fusion/matching.nim
+++ b/src/fusion/matching.nim
@@ -660,14 +660,14 @@ func makeVarSet(
             when compiles($(`varn`)):
               {.line: `ln`.}:
                 raise MatchError(
-                  msg: "Match failure: variable '" & `varStr` &
-                    "' is already set to " & $(`varn`) &
-                    ", and does not match with " & $(`expr`) & "."
+                  msg: "Match failure: capture '" & `varStr` &
+                    "' is already set to '" & $(`varn`) &
+                    "', and does not match with '" & $(`expr`) & "'."
                 )
             else:
               {.line: `ln`.}:
                 raise MatchError(
-                  msg: "Match failure: variable '" & `varStr` &
+                  msg: "Match failure: capture '" & `varStr` &
                     "' is already set and new value does not match."
                 )
          else:
@@ -2495,8 +2495,6 @@ macro assertMatch*(input, pattern: untyped): untyped =
       expr, true, input# .toStrLit().strVal()
     )
 
-  echov vtable
-
   let
     matched = toNode(mexpr, vtable, expr)
 
@@ -2505,9 +2503,6 @@ macro assertMatch*(input, pattern: untyped): untyped =
     let `expr` = `input`
     let ok = `matched`
     discard ok
-
-
-  echov result.repr
 
 
 macro matches*(input, pattern: untyped): untyped =

--- a/src/fusion/matching.nim
+++ b/src/fusion/matching.nim
@@ -223,6 +223,21 @@ func foldInfix(
       nnkInfix.newTree(ident inf, a, b))
 
 
+func nilAccessCondition(condition, access: NimNode): NimNode =
+  nnkInfix.newTree(
+    ident "and",
+    (
+      quote do:
+        block:
+          type AccessType = typeof(`access`)
+          when AccessType is ref: not isNil(`access`)
+          elif AccessType is ptr: not isNil(`access`)
+          else: true
+    ),
+    condition
+  )
+
+
 func commonPrefix(strs: seq[string]): string =
   ## Find common prefix for seq of strings
   if strs.len == 0:
@@ -2276,7 +2291,7 @@ func makeMatchExpr(
 
         else:
           let
-            incheck = nnkInfix.newTree(ident "in", pair.key, accs)
+            incheck = nnkInfix.newTree(ident "in", pair.key, accs).nilAccessCondition(accs)
 
           if not pair.patt.isOptional:
             conds.add nnkInfix.newTree(

--- a/src/fusion/matching.rst
+++ b/src/fusion/matching.rst
@@ -327,8 +327,8 @@ For matching object fields you can use ``(fld: value)`` -
       of (fld1: @capture):
         doAssert capture == 0
 
-For objects with `Option[]` fields it is possible to use `field: opt
-@capture or "default"` to either get capture value, or set it to fallback
+For objects with ``Option[T]`` fields it is possible to use ``field: opt
+@capture or "default"`` to either get capture value, or set it to fallback
 expression.
 
 Variant object matching

--- a/src/fusion/matching.rst
+++ b/src/fusion/matching.rst
@@ -204,8 +204,12 @@ Input sequence: ``[1,2,3,4,5,6,5,6]``
 
     - ``all @val is <expr>``: capture all elements in ``@val`` if ``<expr>``
       is true for every one of them.
+
 ``opt``
-    Single element match
+
+    Optional single element match - if sequence contains less elements than
+    necessary element is considered missing. In that case either `default`
+    fallback (if present) is used as value, or capture is set to `None(T)`.
 
     - ``opt @a``: match optional element and bind it to a
 
@@ -213,7 +217,7 @@ Input sequence: ``[1,2,3,4,5,6,5,6]``
       "default"
 ``any``
     greedy. Consume all sequence elements until the end and
-    succed only if any element has matched.
+    succed only if at least one element has matched.
 
     - ``any @val is "d"``: capture all element that match ``is "d"``
 
@@ -565,6 +569,11 @@ You can use ``opt`` in following situations:
   like ``ref``, or ``ptr`` rules are also the same. If you want to handle
   custom type you can define ``optHasValue()`` and ``optGetOrDefault()``
   procedures.
+
+It also should be noted that `or default` clause makes pattern always
+succed, so in case of `[any (field: @capture or "default")]` resulting
+`capture` will have as many elements as the original sequence but one that
+had "no value", will be filled by `default`.
 
 
 Tree matching

--- a/src/fusion/matching.rst
+++ b/src/fusion/matching.rst
@@ -327,6 +327,10 @@ For matching object fields you can use ``(fld: value)`` -
       of (fld1: @capture):
         doAssert capture == 0
 
+For objects with `Option[]` fields it is possible to use `field: opt
+@capture or "default"` to either get capture value, or set it to fallback
+expression.
+
 Variant object matching
 -----------------------
 
@@ -518,62 +522,6 @@ following functions:
 - ``isSome(): bool`` (for `Some()` pattern check),
 - ``isNone(): bool`` (for `None()` pattern), and
 - ``get(): T`` (for getting value if type is some).
-
-"No-value" matching
--------------------
-
-In addition to explicit ``Option`` type 'no value' can also be represented
-by some special value, like ``nil``. In this case writing ``opt @capture``
-would generate ``None()`` if value is missing. Additionally, ``opt @capture
-or "default"`` can be used to have a fallback value. These pattersn are
-transformed into ``optHasValue()`` check, or ``optGetOrDefault()``
-respectively.
-
-.. code:: nim
-
-    mightReturnNil().matches(opt @someRef or newDefaultT())
-
-    # is transformed into
-
-    let expr = mightReturnNil().optGetOrDefault(newDefaultT())
-
-
-To avoild eager evaluatiopn of default clause it is recommeded to implement
-``optGetOrDefault`` as ``template`` in form of
-
-.. code:: nim
-
-    template optGetOrDefault(value, fallback: T): untyped =
-      let value2 = value
-      if #[user check if expression has value]#:
-        value2
-
-      else:
-        # `else` branch is evaluated only if expression has no value
-        fallback
-
-Notes on ``opt`` vs edge case for ``Option`` - latter one is added as
-special-case support for a type defined ``std/options``, while former one
-should be used to work with "has value" and "no value" elements - ``nil``
-fields, missing array element, or value for non-existent key.
-
-You can use ``opt`` in following situations:
-
-- Optional trailing element in array: ``[@head, opt @tail or default]`` -
-  if sequence only has two elements `default` will be used. Without `or
-  default` clause `tail` will have `Option[_]` type.
-- Optional key-value pair: `{ "key": opt @value or default }` - same rules
-  apply as with sequence. If key cannot be found use `default`, if no
-  default clause capture is an explicit `Option[_]`.
-- 'optional' field: ``(field: opt @capture or default)`. For field types
-  like ``ref``, or ``ptr`` rules are also the same. If you want to handle
-  custom type you can define ``optHasValue()`` and ``optGetOrDefault()``
-  procedures.
-
-It also should be noted that `or default` clause makes pattern always
-succed, so in case of `[any (field: @capture or "default")]` resulting
-`capture` will have as many elements as the original sequence but one that
-had "no value", will be filled by `default`.
 
 
 Tree matching

--- a/src/fusion/matching.rst
+++ b/src/fusion/matching.rst
@@ -42,8 +42,8 @@ Quick reference
 Supported match elements
 ========================
 
-- *seqs* - matched using ``[Patt1(), Patt2(), ..]``. Must have
-  ``len(): int`` and ``[int]: T`` defined.
+- *seqs* - matched using ``[Patt1(), Patt2(), ..]``. Must have ``len():
+  int`` and ``iterator items(): T`` defined.
 - *tuples* - matched using ``(Patt1(), Patt2(), ..)``.
 - *pairable* - matched using ``{Key: Patt()}``. Must have ``[Key]: T``
   defined. ``Key`` is not a pattern - search for whole collection
@@ -506,6 +506,66 @@ Option matching
 ``Some(@x)`` and ``None()`` is a special case that will be rewritten into
 ``(isSome: true, get: @x)`` and ``(isNone: true)`` respectively. This is
 made to allow better integration with optional types.  [9]_ .
+
+Note: implementation does not explicitly require to use
+``std/options.Option`` type, but instead works with anything that provides
+following functions:
+
+- ``isSome(): bool`` (for `Some()` pattern check),
+- ``isNone(): bool`` (for `None()` pattern), and
+- ``get(): T`` (for getting value if type is some).
+
+"No-value" matching
+-------------------
+
+In addition to explicit ``Option`` type 'no value' can also be represented
+by some special value, like ``nil``. In this case writing ``opt @capture``
+would generate ``None()`` if value is missing. Additionally, ``opt @capture
+or "default"`` can be used to have a fallback value. These pattersn are
+transformed into ``optHasValue()`` check, or ``optGetOrDefault()``
+respectively.
+
+.. code:: nim
+
+    mightReturnNil().matches(opt @someRef or newDefaultT())
+
+    # is transformed into
+
+    let expr = mightReturnNil().optGetOrDefault(newDefaultT())
+
+
+To avoild eager evaluatiopn of default clause it is recommeded to implement
+``optGetOrDefault`` as ``template`` in form of
+
+.. code:: nim
+
+    template optGetOrDefault(value, fallback: T): untyped =
+      let value2 = value
+      if #[user check if expression has value]#:
+        value2
+
+      else:
+        # `else` branch is evaluated only if expression has no value
+        fallback
+
+Notes on ``opt`` vs edge case for ``Option`` - latter one is added as
+special-case support for a type defined ``std/options``, while former one
+should be used to work with "has value" and "no value" elements - ``nil``
+fields, missing array element, or value for non-existent key.
+
+You can use ``opt`` in following situations:
+
+- Optional trailing element in array: ``[@head, opt @tail or default]`` -
+  if sequence only has two elements `default` will be used. Without `or
+  default` clause `tail` will have `Option[_]` type.
+- Optional key-value pair: `{ "key": opt @value or default }` - same rules
+  apply as with sequence. If key cannot be found use `default`, if no
+  default clause capture is an explicit `Option[_]`.
+- 'optional' field: ``(field: opt @capture or default)`. For field types
+  like ``ref``, or ``ptr`` rules are also the same. If you want to handle
+  custom type you can define ``optHasValue()`` and ``optGetOrDefault()``
+  procedures.
+
 
 Tree matching
 =============

--- a/src/fusion/matching.rst
+++ b/src/fusion/matching.rst
@@ -424,11 +424,11 @@ Infix operators
 By default object fields are either matched using recursive pattern, or
 compared for equality (when ``field: "some value"`` is used). It is also
 possible to explicitly specify operator, for example using ``=~`` from
-``std/re`` module:
+``std/pegs`` module:
 
 .. code:: nim
     case (parent: (field: "string")):
-      of (parent.field: =~ re"str(.*)"):
+      of (parent.field: =~ peg"str{\w+}"):
         doAssert matches[0] == "ing"
 
 

--- a/src/fusion/matching.rst
+++ b/src/fusion/matching.rst
@@ -81,7 +81,7 @@ like `(len: < 12)` also work as expected.
 
 It is possible to have mixed assess for objects. Mixed object access
 via ``(gg: _, [], {})`` creates the same code for checking. E.g ``([_])``
-is the same as ``[_]``, ``({"key": "val"})`` is is identical to just
+is the same as ``[_]``, ``({"key": "val"})`` and is identical to just
 ``{"key": "val"}``. You can also call functions and check their values
 (like ``(len: _(it < 10))`` or ``(len: in {0 .. 10})``) to check for
 sequence length.
@@ -120,7 +120,7 @@ Examples
 Variable binding
 ================
 
-Match can be bound to new varaible. All variable declarations happen
+Match can be bound to new variable. All variable declarations happen
 via ``@varname`` syntax.
 
 - To bind element to variable without any additional checks do: ``(fld: @varname)``
@@ -157,7 +157,7 @@ Bind variable type
 
 
 ========================== =====================================
- Pattern                     Ijected variables
+ Pattern                     Injected variables
 ========================== =====================================
  ``[@a]``                    ``var a: typeof(expr[0])``
  ``{"key": @val}``           ``var val: typeof(expr["key"])``
@@ -195,7 +195,7 @@ Input sequence: ``[1,2,3,4,5,6,5,6]``
 ``until``
     non-greedy. Match everything until ``<expr>``
 
-    - ``until <expr>``: match all until frist element that matches Expr
+    - ``until <expr>``: match all until the first element that matches Expr
 
 ``all``
     greedy. Match everything that matches ``<expr>``
@@ -207,7 +207,7 @@ Input sequence: ``[1,2,3,4,5,6,5,6]``
 
 ``opt``
 
-    Optional single element match - if sequence contains less elements than
+    Optional single element match - if sequence contains fewer elements than
     necessary element is considered missing. In that case either `default`
     fallback (if present) is used as value, or capture is set to `None(T)`.
 
@@ -217,7 +217,7 @@ Input sequence: ``[1,2,3,4,5,6,5,6]``
       "default"
 ``any``
     greedy. Consume all sequence elements until the end and
-    succed only if at least one element has matched.
+    succeed only if at least one element has matched.
 
     - ``any @val is "d"``: capture all element that match ``is "d"``
 
@@ -260,7 +260,7 @@ Use examples
 
 In addition to working with nested subpatterns it is possible to use
 pattern matching as simple text scanner, similar to strscans. Main
-difference is that it allows to work on arbitrary sequences, meaning it is
+difference is that it allows working on arbitrary sequences, meaning it is
 possible, for example, to operate on tokens, or as in this example on
 strings (for the sake of simplicity).
 
@@ -287,13 +287,17 @@ Input tuple: ``(1, 2, "fa")``
 ============================ ========== ============
  ``(_, _, _)``                **Ok**      Match all
  ``(@a, @a, _)``              **Fail**
- ``(@a is (1 | 2), @a, _)``   **Error**
+ ``(@a is (1 | 2), @a, _)``   **Fail**    [1]
  ``(1, 1 | 2, _)``            **Ok**
 ============================ ========== ============
 
-There are not a lot of features implemented for tuple matching, though it
-should be noted that `:=` operator can be quite handy when it comes to
-unpacking nested tuples -
+- [1] Pattern backtracking is not performed, ``@a`` is first bound to `1`,
+  and in subsequent match attempts pattern fails.
+
+Tuple element matches support any regular match expression like
+``@capture``, and not different from field matches. You can also use ``opt
+@capture or "default"`` in order to assign fallback value on tuple
+unpacking.
 
 .. code:: nim
 
@@ -420,7 +424,7 @@ types.
 
 Note that ``of`` operator is necessary for distinguishing between multiple
 derived objects, or getting fields that are present only in derived types.
-In addition it performs ``isNil()`` check in the object, so it might be
+In addition to it performs ``isNil()`` check in the object, so it might be
 used in cases when you are not dealing with derived types.
 
 Due to ``isNil()`` check this pattern only makes sense when working with

--- a/src/fusion/matching.rst
+++ b/src/fusion/matching.rst
@@ -415,6 +415,56 @@ types of fields might be returned on tuple unpacking, but not mandatory.
 If different fields have varying types ``when`` **must** and ``static`` be
 used to allow for compile-time code selection.
 
+Predicates and infix operators
+------------------------------
+
+Infix operators
+~~~~~~~~~~~~~~~
+
+By default object fields are either matched using recursive pattern, or
+compared for equality (when ``field: "some value"`` is used). It is also
+possible to explicitly specify operator, for example using ``=~`` from
+``std/re`` module:
+
+.. code:: nim
+    case (parent: (field: "string")):
+      of (parent.field: =~ re"str(.*)"):
+        doAssert matches[0] == "ing"
+
+
+It should be noted that implicitly injected ``matches`` variable is also
+visible in the case branch.
+
+
+Custom predicates
+~~~~~~~~~~~~~~~~~
+
+Matching expressions using custom predicates is also possible. If it is not
+necessary to capture matched element placeholder ``_.`` should be used as a
+first argument:
+
+
+.. code:: nim
+
+    proc lenEq(s: openarray[int], value: int): bool = s.len == value
+
+    case [1, 2]:
+      of _.lenEq(3):
+        # fails
+
+      of _.lenEq(2):
+        # matches
+
+To capture value using predicate placeholder can be replaced with
+``@capture`` pattern:
+
+.. code:: nim
+
+    let arr = @[@[1, 2], @[2, 3], @[4]]
+    discard arr.matches([any @capture.lenEq(2)])
+    doAssert capture == @[@[1, 2], @[2, 3]]
+
+
 Ref object matching
 -------------------
 

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -1,2 +1,2 @@
 switch("path", "$projectDir/../src")
-switch("styleCheck", "error")
+switch("styleCheck", "hint")

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -1,2 +1,2 @@
 switch("path", "$projectDir/../src")
-switch("styleCheck", "hint")
+switch("styleCheck", "error")

--- a/tests/tmatching.nim
+++ b/tests/tmatching.nim
@@ -2697,6 +2697,8 @@ nscd:x:28:28:NSCD Daemon:/:/sbin/nologin"""
 
     doAssert res is seq[string]
 
+import std/[compilesettings]
+
 suite "Tests":
   type
     Kind1 = enum
@@ -2716,3 +2718,10 @@ suite "Tests":
 
       else:
         testFail()
+
+  test "Zzz":
+    type
+      KK = object
+        kind: SingleValueSetting
+
+    arguments() := KK(kind: arguments)

--- a/tests/tmatching.nim
+++ b/tests/tmatching.nim
@@ -74,6 +74,18 @@ suite "Issue tests":
     case O(kind:O2,o2:some[string]("hello world")):
       of O2(o2:Some(@mystring)): echo mystring
 
+  test "Support qualified variant selectors with matching? #83":
+    type
+      ZKind = enum Z1
+      Z = object
+        case kind: ZKind
+          of Z1:
+            o1: int
+
+    case Z(kind: Z1, o1: 1):
+      of ZKind.Z1(o1: @i):
+        doAssert i == 1
+
 suite "Matching":
   test "Pattern parser tests":
     macro main(): untyped =

--- a/tests/tmatching.nim
+++ b/tests/tmatching.nim
@@ -777,7 +777,9 @@ suite "Matching":
     [all (len: < 10)] := [@[1,2,3,4], @[1,2,3,4]]
     [all _.startsWith("--")] := @["--", "--", "--=="]
 
-    block: [@a.startsWith("--")] := ["--12"]
+    block:
+      [@a.startsWith("--")] := ["--12"]
+      doAssert a == "--12"
 
     proc exception() =
       # This should generate quite nice exception message:
@@ -788,6 +790,21 @@ suite "Matching":
 
     expect MatchError:
       exception()
+
+  multitest "Decision matrix":
+    proc test1(str, arg: string): bool = str == arg
+    proc test2(str, arg: string): bool = str == arg
+
+    case ("1", "2"):
+      of (_.test1("1"), _.test2("1")):
+        testFail()
+
+      of (_.test1("1"), _.test2("2")):
+        discard
+
+      else:
+        testFail()
+
 
   multitest "One-or-more":
     case [1]:
@@ -1848,6 +1865,7 @@ suite "Gara tests":
 
     if a.matches((b: 0)):
       discard
+
     else:
       testFail()
 
@@ -1857,9 +1875,10 @@ suite "More tests":
 
     case [s]
       of [(len: > 5)]:
-        echo "len more than 5"
+        discard
+
       else:
-        echo "nope"
+        testFail()
 
   multitest "Matching boolean tables":
     case (true, false, false):

--- a/tests/tmatching.nim
+++ b/tests/tmatching.nim
@@ -2696,3 +2696,23 @@ nscd:x:28:28:NSCD Daemon:/:/sbin/nologin"""
         shell
 
     doAssert res is seq[string]
+
+suite "Tests":
+  type
+    Kind1 = enum
+      k1First
+      k1Second
+      k1Third
+
+    Kidn2 = enum
+      k2First
+      k2Second
+      k2Third
+
+  test "Nested kind switches":
+    case (k1First, k2Second):
+      of (in {k1First, k1Second}, _):
+        discard
+
+      else:
+        testFail()

--- a/tests/tmatching.nim
+++ b/tests/tmatching.nim
@@ -80,9 +80,9 @@ suite "Matching":
       doAssert (t true).kind == kItem
       block:
         let s = t [1, 2, all @b, @a]
-        doAssert s.seqElems[3].bindVar == some(ident("a"))
-        doAssert s.seqElems[2].bindVar == some(ident("b"))
-        doAssert s.seqElems[2].patt.bindVar == none(NimNode)
+        doAssert s.seqElements[3].bindVar == some(ident("a"))
+        doAssert s.seqElements[2].bindVar == some(ident("b"))
+        doAssert s.seqElements[2].pattern.bindVar == none(NimNode)
 
       discard t([1,2,3,4])
       discard t((1,2))

--- a/tests/tmatching.nim
+++ b/tests/tmatching.nim
@@ -1,4 +1,4 @@
-import std/[strutils, sequtils, strformat, sugar,
+import std/[strutils, sequtils, strformat, sugar, re,
             macros, options, tables, json]
 
 import fusion/matching
@@ -2334,6 +2334,37 @@ suite "Article examples":
 
       else:
         testFail()
+
+  test "Predicates and infix operators":
+    case (field: "string"):
+      of (field: =~ re"str(.*)"):
+        doAssert matches[0] == "ing"
+
+      else:
+        testFail()
+
+    case (parent: (field: "string")):
+      of (parent.field: =~ re"str(.*)"):
+        doAssert matches[0] == "ing"
+
+      else:
+        testFail()
+
+
+    proc lenEq(s: openarray[int], value: int): bool = s.len == value
+
+    case [1, 2]:
+      of _.lenEq(3):
+        testFail()
+
+      of _.lenEq(2):
+        discard
+
+    let arr = @[@[1, 2], @[2, 3], @[4]]
+    discard arr.matches([any @capture.lenEq(2)])
+    doAssert capture == @[@[1, 2], @[2, 3]]
+
+
 
   multitest "Optional object field matches":
     type

--- a/tests/tmatching.nim
+++ b/tests/tmatching.nim
@@ -1840,6 +1840,15 @@ suite "Gara tests":
       testfail()
 
 suite "More tests":
+  multitest "String len":
+    let s = "test string"
+
+    case [s]
+      of [(len: > 5)]:
+        echo "len more than 5"
+      else:
+        echo "nope"
+
   multitest "Matching boolean tables":
     case (true, false, false):
       of (true, false, false):

--- a/tests/tmatching.nim
+++ b/tests/tmatching.nim
@@ -248,7 +248,7 @@ suite "Matching":
       of [_]: discard
 
     case [1,2,3,4]:
-      of [_]: testfail()
+      of [_]: testFail()
       of [_, 2, 3, _]:
         discard
 
@@ -384,22 +384,22 @@ suite "Matching":
 
     case (c: (a: 12)):
       of (c: (a: _)): discard
-      else: testfail()
+      else: testFail()
 
     case [(a: 12, b: 3)]:
-      of [(a: 12, b: 22)]: testfail()
+      of [(a: 12, b: 22)]: testFail()
       of [(a: _, b: _)]: discard
 
     case (c: [3, 3, 4]):
       of (c: [_, _, _]): discard
-      of (c: _): testfail()
+      of (c: _): testFail()
 
     case (c: [(a: [1, 3])]):
-      of (c: [(a: [_])]): testfail()
+      of (c: [(a: [_])]): testFail()
       else: discard
 
     case (c: [(a: [1, 3]), (a: [1, 4])]):
-      of (c: [(a: [_]), _]): testfail()
+      of (c: [(a: [_]), _]): testFail()
       else:
         discard
 
@@ -407,21 +407,21 @@ suite "Matching":
       of enEE(eee: [(kind: enZZ, fl: 12)]):
         discard
       else:
-        testfail()
+        testFail()
 
     case Obj2():
       of enEE():
         discard
       of enZZ():
-        testfail()
+        testFail()
       else:
-        testfail()
+        testFail()
 
     case Obj2():
       of (kind: in {enEE, enEE1}):
         discard
       else:
-        testfail()
+        testFail()
 
   func len(o: Obj2): int = o.eee.len
   iterator items(o: Obj2): Obj2 =
@@ -433,22 +433,22 @@ suite "Matching":
       of [_, _]:
         discard
       else:
-        testfail()
+        testFail()
 
     case Obj2(kind: enEE, eee: @[Obj2(), Obj2()]):
-      of EE(eee: [_, _, _]): testfail()
+      of EE(eee: [_, _, _]): testFail()
       of EE(eee: [_, _]): discard
-      else: testfail()
+      else: testFail()
 
     case Obj2(kind: enEE1, eee: @[Obj2(), Obj2()]):
       of EE([_, _]):
-        testfail()
+        testFail()
       of EE1([_, _, _]):
-        testfail()
+        testFail()
       of EE1([_, _]):
         discard
       else:
-        testfail()
+        testFail()
 
 
 
@@ -458,7 +458,7 @@ suite "Matching":
         of ($a, $a, $a, $a):
           discard
         else:
-          testfail()
+          testFail()
 
     assertEq "122", case (a: 12, b: 2):
                       of (a: @a, b: @b): $a & $b
@@ -573,7 +573,7 @@ suite "Matching":
   multitest "Set":
     case [3]:
       of [{2, 3}]: discard
-      else: testfail()
+      else: testFail()
 
     [{'a' .. 'z'}, {' ', '*'}] := "z "
 
@@ -678,13 +678,13 @@ suite "Matching":
       of [any @elem is JString()]:
         discard
       else:
-        testfail()
+        testFail()
 
     case ("foo", 78)
       of ("foo", 78):
         discard
       of ("bar", 88):
-        testfail()
+        testFail()
 
     block: Some(@x) := some("hello")
 
@@ -733,19 +733,19 @@ suite "Matching":
     proc g1[T](a: seq[T]): T =
       case a:
         of [@a]: discard
-        else: testfail()
+        else: testFail()
 
       expand case a:
         of [_]: discard
-        else: testfail()
+        else: testFail()
 
       expand case a:
         of [_.startsWith("--")]: discard
-        else: testfail()
+        else: testFail()
 
       expand case a:
         of [(len: < 12)]: discard
-        else: testfail()
+        else: testFail()
 
     discard g1(@["---===---=="])
 
@@ -753,9 +753,9 @@ suite "Matching":
   test "Predicates":
     case ["hello"]:
       of [_.startsWith("--")]:
-        testfail()
+        testFail()
       of [_.startsWith("==")]:
-        testfail()
+        testFail()
       else:
         discard
 
@@ -780,17 +780,17 @@ suite "Matching":
   multitest "One-or-more":
     case [1]:
       of [@a]: assertEq a, 1
-      else: testfail()
+      else: testFail()
 
     case [1]:
       of [all @a]: assertEq a, @[1]
-      else: testfail()
+      else: testFail()
 
     case [1,2,3,4]:
       of [_, until @a is 4, 4]:
         assertEq a, @[2,3]
       else:
-        testfail()
+        testFail()
 
 
     case [1,2,3,4]:
@@ -798,7 +798,7 @@ suite "Matching":
         doAssert a is int
         doAssert a == 1
       else:
-        testfail()
+        testFail()
 
 
     case [1,2,3,4]:
@@ -806,7 +806,7 @@ suite "Matching":
         doAssert a is seq[int]
         doAssert a == @[1,2,3,4]
       else:
-        testfail()
+        testFail()
 
   multitest "Optional matches":
     case [1,2,3,4]:
@@ -1057,7 +1057,7 @@ suite "Matching":
     block:
       case (true, false):
         of (@a, @a):
-          testfail()
+          testFail()
         of (@a, _):
           doAssert a == true
 
@@ -1174,7 +1174,7 @@ suite "Matching":
       of (f1: (f2: (f3: < 10))):
         discard
       else:
-        testfail()
+        testFail()
 
   multitest "Nested key access":
     let val = (@[1,2,3], @[3,4,5])
@@ -1183,7 +1183,7 @@ suite "Matching":
       of ((len: <= 3), (len: <= 3)):
         discard
       else:
-        testfail()
+        testFail()
 
     let val2 = (hello: @[1,2,3])
 
@@ -1191,7 +1191,7 @@ suite "Matching":
       of (hello.len: <= 3):
         discard
       else:
-        testfail()
+        testFail()
 
 
     let val3 = (hello3: @[@[@["eee"]]])
@@ -1223,7 +1223,7 @@ suite "Matching":
     try:
       [_, any is (1 | 2)] := [3,4,5]
 
-      testfail("_, any is (1 | 2)")
+      testFail("_, any is (1 | 2)")
 
     except MatchError:
       let msg = getCurrentExceptionMsg()
@@ -1249,7 +1249,7 @@ suite "Matching":
 
     try:
       [(1 | 2)] := [3]
-      testfail("[(1 | 2)] := [3]")
+      testFail("[(1 | 2)] := [3]")
     except MatchError:
       doAssert "pattern '(1 | 2)'" in getCurrentExceptionMsg()
 
@@ -1315,7 +1315,7 @@ suite "Matching":
       of (fld3: @subf):
         discard
       else:
-        testfail()
+        testFail()
 
     var tmp: Root = SubRoot(fld3: 12)
     doAssert tmp.SubRoot().fld3 == 12
@@ -1323,7 +1323,7 @@ suite "Matching":
       of of SubRoot(fld3: @subf):
         doAssert subf == 12
       else:
-        testfail()
+        testFail()
 
   multitest "Ref object in maps, subfields and sequences":
     block:
@@ -1503,7 +1503,7 @@ suite "Gara tests":
       of [@b == 2]:
         assertEq b, 2
       else:
-        testfail()
+        testFail()
 
 
   multitest "Object":
@@ -1511,11 +1511,11 @@ suite "Gara tests":
 
     case a:
       of (a: 4, b: 1):
-        testfail()
+        testFail()
       of (a: 2, b: @b):
         assertEq b, 0
       else :
-        testfail()
+        testFail()
 
   multitest "Subpattern":
     let repo = Repo(
@@ -1531,7 +1531,7 @@ suite "Gara tests":
 
     case repo:
       of (name: "New", commits: == @[]):
-        testfail()
+        testFail()
       of (
         name: @name,
         author: (
@@ -1543,7 +1543,7 @@ suite "Gara tests":
         assertEq name, "ExampleDB"
         assertEq email.raw, "example@exampledb.org"
       else:
-        testfail()
+        testFail()
 
   test "Sequence":
     let a = @[
@@ -1554,11 +1554,11 @@ suite "Gara tests":
 
     case a:
       of []:
-        testfail()
+        testFail()
       of [_, all @others is (a: 4, b: 4)]:
         assertEq others, a[1 .. ^1]
       else:
-        testfail()
+        testFail()
 
     # _ is always true, (a: 4, b: 4) didn't match element 2
 
@@ -1722,7 +1722,7 @@ suite "Gara tests":
 
     case email:
       of (data: (name: "academy")):
-        testfail()
+        testFail()
 
       of (tokens: [_, _, _, _, @token]):
         assertEq token, "org"
@@ -1734,7 +1734,7 @@ suite "Gara tests":
       of [_, @t(it mod 2 == 0)]:
         assertEq t, 0
       else:
-        testfail()
+        testFail()
 
   multitest "unification":
     let b = @["nim", "nim", "c++"]
@@ -1750,11 +1750,11 @@ suite "Gara tests":
 
     case b:
       of [@x, @x, @x]:
-        testfail()
+        testFail()
       of [@x, @x, _]:
         assertEq x, "nim"
       else:
-        testfail()
+        testFail()
 
   multitest "option":
     let a = some[int](3)
@@ -1763,7 +1763,7 @@ suite "Gara tests":
       of Some(@i):
         assertEq i, 3
       else:
-        testfail()
+        testFail()
 
 
   multitest "nameless tuple":
@@ -1771,13 +1771,13 @@ suite "Gara tests":
 
     case a:
       of ("a", "c"):
-        testfail()
+        testFail()
       of ("a", "c"):
-        testfail()
+        testFail()
       of ("a", @c):
         assertEq c, "b"
       else:
-        testfail()
+        testFail()
 
   multitest "ref":
     type
@@ -1791,13 +1791,13 @@ suite "Gara tests":
       of (name: @name):
         assertEq name, "2"
       else:
-        testfail()
+        testFail()
 
     let node2: Node = nil
 
     case node2:
       of (isNil: false, name: "4"):
-        testfail()
+        testFail()
       else:
         discard
 
@@ -1808,7 +1808,7 @@ suite "Gara tests":
       of [4'i8]:
         discard
       else:
-        testfail()
+        testFail()
 
   multitest "dot access":
     let a = Rectangle(b: 4)
@@ -1817,19 +1817,19 @@ suite "Gara tests":
       of (b: == a.b):
         discard
       else:
-        testfail()
+        testFail()
 
   multitest "arrays":
     let a = [1, 2, 3, 4]
 
     case a:
       of [1, @a, 3, @b, 5]:
-        testfail()
+        testFail()
       of [1, @a, 3, @b]:
         assertEq a, 2
         assertEq b, 4
       else:
-        testfail()
+        testFail()
 
   multitest "bool":
     let a = Rectangle(a: 0, b: 0)
@@ -1837,7 +1837,7 @@ suite "Gara tests":
     if a.matches((b: 0)):
       discard
     else:
-      testfail()
+      testFail()
 
 suite "More tests":
   multitest "String len":
@@ -1900,7 +1900,7 @@ suite "More tests":
 
         of ["get", @objectName]:
           doAssert "get" in cmd
-          doASsert objectName == "test"
+          doAssert objectName == "test"
 
         of ["go", (parseDirection: @direction)]:
           case direction:
@@ -2510,7 +2510,7 @@ mail:x:8:12::/var/spool/mail:/usr/bin/nologin
   test "example from documentation":
     case [(1, 3), (3, 4)]:
       of [(1, @a), _]:
-        doASsert a == 3
+        doAssert a == 3
 
       else:
         fail()
@@ -2732,7 +2732,7 @@ mail:x:8:12::/var/spool/mail:/usr/bin/nologin
 
           for it0 {.inject.} in `arg`:
             `evalExpr`
-            `resId`.add `lastid`
+            `resId`.add `lastId`
 
           `resId`
       else:

--- a/tests/tmatching.nim
+++ b/tests/tmatching.nim
@@ -2311,21 +2311,46 @@ suite "Article examples":
         field2: Option[float]
 
     block: (field1: opt @capture or 12) := Obj90(); doAssert capture == 12
-    when false:
-      block: doAssert not matches(Obj90(), (field2: opt @capture) ?= Obj90())
-      block: doAssert matches(Obj90(), (field1: opt @c or 1))
-      block: doAssert matches((none(12), some(2)), (opt @h or 1, _))
-      block:
-        matches([
-          (none(12), some(0)),
-          (none(12), some(0)),
-          (none(2), some(90))
-        ], [
-          any (opt @head or 12, _)
-        ])
+    block: doAssert not matches(Obj90(), (field2: opt @capture))
+    block: doAssert matches(Obj90(), (field1: opt @c or 1))
+    block: doAssert matches((none(int), some(2)), (opt @h or 1, _))
+    block:
+      assertMatch([
+        (some(12), some(0)),
+        (some(12), some(0)),
+        (none(int), some(90))
+      ], [
+        any (opt @head or 12, _)
+      ])
 
-        doAssert head is seq[int]
-        doAssert head == @[12, 12, 12]
+      doAssert head is seq[int]
+      doAssert head == @[12, 12, 12]
+
+  test "`opt` for objects":
+    type
+      Settings = object of RootObj
+        config: JsonNode
+        company: Option[string]
+        id: Option[string]
+        secret: Option[string]
+        savePosition: bool
+        alwaysOnTop: bool
+
+
+    discard Settings().matches((
+      company: opt @c or "",
+      savePosition: @pch,
+      alwaysOnTop: @aot,
+      config: {
+        "a": opt @b or JsonNode(),
+        "b": opt @q
+      }
+    ))
+
+    doAssert c is string
+    doAssert pch is bool
+    doAssert b is JsonNode
+    doAssert q is Option[JsonNode]
 
 
 

--- a/tests/tmatching.nim
+++ b/tests/tmatching.nim
@@ -55,6 +55,23 @@ template t(body: untyped): untyped =
 
 
 suite "Issue tests":
+  test "Duplicated unpacking":
+    [all [@head < 10, _]] := @[[1, 2], [3, 4], [5, 6]]
+    doAssert head.len == 3
+
+    macro sumt(arg: untyped): untyped =
+      Asgn[@name is Ident(), Call[_, [all @typeFields]]] := arg[0]
+      [all Call[@names is Ident(), _]] := typeFields
+
+      doAssert names.len == 3
+
+    sumt:
+      Name = sumtype:
+        Kind1(string)
+        Kind2(float)
+        Kind3(char)
+
+
   test "`matching` bug with `{orc,arc}` #76":
     # Compilation failed with `--gc:orc` enabled
     macro parseTests(): untyped =

--- a/tests/tmatching.nim
+++ b/tests/tmatching.nim
@@ -2304,6 +2304,29 @@ suite "Article examples":
       else:
         testFail()
 
+  multitest "Optional object field matches":
+    type
+      Obj90 = object
+        field1: Option[int]
+        field2: Option[float]
+
+    block: (field1: opt @capture or 12) := Obj90(); doAssert capture == 12
+    when false:
+      block: doAssert not matches(Obj90(), (field2: opt @capture) ?= Obj90())
+      block: doAssert matches(Obj90(), (field1: opt @c or 1))
+      block: doAssert matches((none(12), some(2)), (opt @h or 1, _))
+      block:
+        matches([
+          (none(12), some(0)),
+          (none(12), some(0)),
+          (none(2), some(90))
+        ], [
+          any (opt @head or 12, _)
+        ])
+
+        doAssert head is seq[int]
+        doAssert head == @[12, 12, 12]
+
 
 
 

--- a/tests/tmatching.nim
+++ b/tests/tmatching.nim
@@ -1,4 +1,4 @@
-import std/[strutils, sequtils, strformat, sugar, re,
+import std/[strutils, sequtils, strformat, sugar, pegs,
             macros, options, tables, json]
 
 import fusion/matching
@@ -2337,14 +2337,14 @@ suite "Article examples":
 
   test "Predicates and infix operators":
     case (field: "string"):
-      of (field: =~ re"str(.*)"):
+      of (field: =~ peg"str{\w+}"):
         doAssert matches[0] == "ing"
 
       else:
         testFail()
 
     case (parent: (field: "string")):
-      of (parent.field: =~ re"str(.*)"):
+      of (parent.field: =~ peg"str{\w+}"):
         doAssert matches[0] == "ing"
 
       else:


### PR DESCRIPTION
Enabling `--gc:{orc,arc}` caused macro to behave differently, by somehow mutating **immutable** access path passed to the match expression generator. I wasn't able to reliably reproduce the bug, but it wasn't related to implementation itself.

Fixed that by explicitly copying path each time it is passed around - usually it is a sequence of 3-4 access elements, and copying only happens during macro evaluation.

Related: https://github.com/nim-lang/fusion/issues/76