### PR TITLE
Run CI tests with arc/orc in addition to default GC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,13 @@ jobs:
 
       - name: Run tests
         shell: bash
-        run: nimble test
+        run: |
+          nimble test
+          if [[ '${{ matrix.branch }}' != 'version-1-0' ]]; then
+            nimble test --gc:orc
+            nimble test --gc:arc
+
+          fi
 
       - name: Build docs
         if: matrix.branch == 'devel'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,12 +108,7 @@ jobs:
       - name: Run tests
         shell: bash
         run: |
-          nimble test
-          if [[ '${{ matrix.branch }}' != 'version-1-0' ]]; then
-            nimble test --gc:orc
-            nimble test --gc:arc
-
-          fi
+          nimble testMulti
 
       - name: Build docs
         if: matrix.branch == 'devel'

--- a/fusion.nimble
+++ b/fusion.nimble
@@ -16,3 +16,9 @@ task docs, "":
     exec "nim c -r -d:fusionDocJs src/fusion/docutils " & srcDir
   # C
   exec "nim c -r src/fusion/docutils " & srcDir
+
+task testMulti, "Execute test suite with different GC options":
+  exec "nimble test"
+  when (NimMajor, NimMinor) >= (1, 2):
+    exec "nimble test --gc:arc"
+    exec "nimble test --gc:orc"


### PR DESCRIPTION
Right now all fusion tests pass with orc/arc enabled (with #77 pattern matching passes too), but I think it is necessary to also test compilation with non-default GC.