### PR TITLE
Add jsstrformat

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,3 +19,5 @@
 - Added `jssets` module, Set for the JavaScript target
   https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
 - Added `jsheaders` module for [`Headers`](https://developer.mozilla.org/en-US/docs/Web/API/Headers) for the JavaScript target.
+
+- Added `jsstrformat` module for [JavaScript string template literal interpolation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals).

--- a/src/fusion/js/jsstrformat.nim
+++ b/src/fusion/js/jsstrformat.nim
@@ -1,0 +1,54 @@
+## * JavaScript string template literal interpolation.
+when not defined(js):
+  {.fatal: "Module jsstrformat is designed to be used with the JavaScript backend.".}
+
+template jsUnsafeFmt*(code: untyped) =
+  ## JavaScript string template literal interpolation for `cstring`.
+  ##
+  ## This is not meant to be better or even equal than normal stdlib `strformat`,
+  ## is just for when you need faster performance and string interpolation for JavaScript targets,
+  ## otherwise use the normal `strformat` for better user experience.
+  ##
+  ## .. Note:: To use any Nim symbols inside the string interpolation block,
+  ##           the symbol declaration must have the `{.exportc.}` pragma.
+  ##
+  ## .. Warning:: This is unsafe, but has zero cost in performance.
+  ##              Debugging with `fmt"{expr=}"` is NOT supported.
+  ##
+  ## See also:
+  ## * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals
+  ## * https://caniuse.com/template-literals
+  ## * https://tc39.es/ecma262/#sec-template-literals
+  ## * `strformat <strformat.html>`_
+  runnableExamples:
+    jsUnsafeFmt:
+      assert fmt"" == "" ## Empty string is Ok.
+      let foo {.exportc.} = "platypus".cstring
+      var bar {.exportc.} = "capybara".cstring
+      assert fmt"${foo}" == "platypus".cstring
+      assert fmt("foo ${foo} bar ${bar} baz ${8 + 1} !?".cstring) == "foo platypus bar capybara baz 9 !?".cstring
+
+    jsUnsafeFmt:
+      let a {.exportc.} = 1
+      let b {.exportc.} = 2  ## Triple-quoted and multi-line string is Ok.
+      assert &"""\ ${(a + b * a + b)} \t ${3.14} \n /""".cstring == """\ 5 \t 3.14 \n /""".cstring
+
+    var str: cstring
+    jsUnsafeFmt:
+      assert fmt"${  -1.234560e+02  } ${-0.0} {42} ${0.0} $0 $$ {{{}}}" == "-123.456 0 {42} 0 $0 $$ {{{}}}".cstring
+      assert fmt"{123.456=}" == "{123.456=}".cstring  ## Debug with `=` NOT supported.
+      str = fmt"${         1_000_000         }"
+    assert str == "1000000"
+
+  block:
+    func fmt(s: cstring): cstring {.importjs: "fmt`#`".}
+
+    func `&`(s: cstring): cstring {.importjs: "fmt`#`".}
+
+    func jsFmtInjectFmt {.importjs: """const fmt = (strings, ...values) => {
+    return values.reduce((finalString, value, index) => {
+      return `$${finalString}$${value}$${strings[index + 1]}`}, strings[0]).slice(1, -1)
+    }""".}
+
+    jsFmtInjectFmt()
+    code

--- a/src/fusion/js/jsstrformat.nim
+++ b/src/fusion/js/jsstrformat.nim
@@ -41,9 +41,9 @@ template jsUnsafeFmt*(code: untyped) =
     assert str == "1000000"
 
   block:
-    func fmt(s: cstring): cstring {.importjs: "fmt`#`".}
+    func fmt(s: cstring): cstring {.importjs: "fmt`#`", used.}
 
-    func `&`(s: cstring): cstring {.importjs: "fmt`#`".}
+    func `&`(s: cstring): cstring {.importjs: "fmt`#`", used.}
 
     func jsFmtInjectFmt {.importjs: """const fmt = (strings, ...values) => {
     return values.reduce((finalString, value, index) => {


### PR DESCRIPTION
- [JavaScript string template literal interpolation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals).
- Documentation with links and `runnableExamples` with `assert`.
- From Nim side, uses a `strformat` like API; From JavaScript side, emits a backticks-based string interpolation.
- Unsafe, but very good performance, safe API can be added in the future, no more unsafe than a `cast`or `emit` anyways... :shrug: 

```nim
jsUnsafeFmt:
  console.log fmt"text ${1 + 2 * 4 - 1} text ${somevariable} text ${somesymbol} text!."  
```

Compiles to:

```javascript
console.log( `text ${1 + 2 * 4 - 1} text ${somevariable} text ${somesymbol} text!.` );
```
