### PR TITLE
[RFC] New module for thread synchronization.

### DIFF
--- a/src/fusion/sync.nim
+++ b/src/fusion/sync.nim
@@ -1,0 +1,214 @@
+import std / locks
+
+when not compileOption("threads"):
+  {.error: "This module requires --threads:on compilation flag".}
+
+{.push stackTrace: off.}
+
+type
+  Arc*[T] = object
+    val: ptr tuple[value: T, atomicCounter: int]
+
+proc `=destroy`*[T](p: var Arc[T]) =
+  mixin `=destroy`
+  if p.val != nil:
+    if atomicLoadN(addr p.val[].atomicCounter, AtomicConsume) == 0:
+      `=destroy`(p.val[])
+      deallocShared(p.val)
+    else:
+      discard atomicDec(p.val[].atomicCounter)
+
+proc `=copy`*[T](dest: var Arc[T], src: Arc[T]) =
+  if src.val != nil:
+    discard atomicInc(src.val[].atomicCounter)
+  if dest.val != nil:
+    `=destroy`(dest)
+  dest.val = src.val
+
+proc newArc*[T](val: sink T): Arc[T] {.nodestroy.} =
+  result.val = cast[typeof(result.val)](allocShared(sizeof(result.val[])))
+  result.val.atomicCounter = 0
+  result.val.value = val
+
+proc isNil*[T](p: Arc[T]): bool {.inline.} =
+  p.val == nil
+
+proc `[]`*[T](p: Arc[T]): var T {.inline.} =
+  when compileOption("boundChecks"):
+    doAssert(p.val != nil, "deferencing nil shared pointer")
+  p.val.value
+
+proc `$`*[T](p: Arc[T]): string {.inline.} =
+  if p.val == nil: "Arc[" & $T & "](nil)"
+  else: "Arc[" & $T & "](" & $p.val.value & ")"
+
+type
+  SpinLock* = object
+    lock: bool
+
+proc acquire*(s: var SpinLock) =
+  while true:
+    if not atomicExchangeN(addr s.lock, true, AtomicAcquire):
+      return
+    else:
+      while atomicLoadN(addr s.lock, AtomicRelaxed): cpuRelax()
+
+proc tryAcquire*(s: var SpinLock): bool =
+  result = not atomicLoadN(addr s.lock, AtomicRelaxed) and
+      not atomicExchangeN(addr s.lock, true, AtomicAcquire)
+
+proc release*(s: var SpinLock) =
+  atomicStoreN(addr s.lock, false, AtomicRelease)
+
+template withLock*(a: SpinLock, body: untyped) =
+  acquire(a)
+  try:
+    body
+  finally:
+    release(a)
+
+type
+  Once* = object
+    L: Lock
+    finished: bool
+
+proc initOnce*(o: var Once) =
+  initLock(o.L)
+  o.finished = false
+
+proc destroyOnce*(o: var Once) {.inline.} =
+  deinitLock(o.L)
+
+template once*(o: Once, body: untyped) =
+  if not atomicLoadN(addr o.finished, AtomicAcquire):
+    acquire o.L
+    try:
+      if not o.finished:
+        try:
+          body
+        finally:
+          atomicStoreN(addr o.finished, true, AtomicRelease)
+    finally:
+      release o.L
+
+type
+  Semaphore* = object
+    c: Cond
+    L: Lock
+    counter: int
+
+proc initSemaphore*(s: var Semaphore; value: Natural = 0) =
+  initCond(s.c)
+  initLock(s.L)
+  s.counter = value
+
+proc destroySemaphore*(s: var Semaphore) {.inline.} =
+  deinitCond(s.c)
+  deinitLock(s.L)
+
+proc blockUntil*(s: var Semaphore) =
+  acquire(s.L)
+  while s.counter <= 0:
+    wait(s.c, s.L)
+  dec s.counter
+  release(s.L)
+
+proc signal*(s: var Semaphore) =
+  acquire(s.L)
+  inc s.counter
+  signal(s.c)
+  release(s.L)
+
+type
+  Barrier* = object
+    c: Cond
+    L: Lock
+    required: int # number of threads needed for the barrier to continue
+    left: int # current barrier count, number of threads still needed.
+    cycle: uint # generation count
+
+proc initBarrier*(b: var Barrier; count: Natural) =
+  b.required = count
+  b.left = count
+  b.cycle = 0
+  initCond(b.c)
+  initLock(b.L)
+
+proc destroyBarrier*(b: var Barrier) {.inline.} =
+  deinitCond(b.c)
+  deinitLock(b.L)
+
+proc wait*(b: var Barrier) =
+  acquire(b.L)
+  dec b.left
+  if b.left == 0:
+    inc b.cycle
+    b.left = b.required
+    broadcast(b.c)
+  else:
+    let cycle = b.cycle
+    while cycle == b.cycle:
+      wait(b.c, b.L)
+  release(b.L)
+
+type
+  RwMonitor* = object
+    readPhase: Cond
+    writePhase: Cond
+    L: Lock
+    counter: int # can be in three states: free = 0, reading > 0, writing = -1
+
+proc initRwMonitor*(rw: var RwMonitor) =
+  initCond rw.readPhase
+  initCond rw.writePhase
+  initLock rw.L
+  rw.counter = 0
+
+proc destroyRwMonitor*(rw: var RwMonitor) {.inline.} =
+  deinitCond(rw.readPhase)
+  deinitCond(rw.writePhase)
+  deinitLock(rw.L)
+
+proc beginRead*(rw: var RwMonitor) =
+  acquire(rw.L)
+  while rw.counter == -1:
+    wait(rw.readPhase, rw.L)
+  inc rw.counter
+  release(rw.L)
+
+proc beginWrite*(rw: var RwMonitor) =
+  acquire(rw.L)
+  while rw.counter != 0:
+    wait(rw.writePhase, rw.L)
+  rw.counter = -1
+  release(rw.L)
+
+proc endRead*(rw: var RwMonitor) =
+  acquire(rw.L)
+  dec rw.counter
+  if rw.counter == 0:
+    rw.writePhase.signal()
+  release(rw.L)
+
+proc endWrite*(rw: var RwMonitor) =
+  acquire(rw.L)
+  rw.counter = 0
+  rw.readPhase.broadcast()
+  rw.writePhase.signal()
+  release(rw.L)
+
+template readWith*(a: RwMonitor, body: untyped) =
+  beginRead(a)
+  try:
+    body
+  finally:
+    endRead(a)
+
+template writeWith*(a: RwMonitor, body: untyped) =
+  beginWrite(a)
+  try:
+    body
+  finally:
+    endWrite(a)
+
+{.pop.}

--- a/tests/tspinlock.nim
+++ b/tests/tspinlock.nim
@@ -1,0 +1,21 @@
+import sync, std / os
+
+var
+  data = 0
+  thread: Thread[void]
+  lock: SpinLock
+
+proc threadFn =
+  withLock lock:
+    data = 1
+
+proc sleep() =
+  withLock lock:
+    createThread(thread, threadFn)
+    sleep(50)
+    assert data == 0
+  joinThread(thread)
+  withLock lock:
+    assert data == 1
+
+sleep()

--- a/tests/tspinlock.nim
+++ b/tests/tspinlock.nim
@@ -1,4 +1,4 @@
-import sync, std / os
+import fusion / sync, std / os
 
 var
   data = 0


### PR DESCRIPTION
This gathers some useful thread synchronization primitives gathered from various sources. It includes:

- `SpinLock` implementation, based on https://rigtorp.se/spinlock/
- `Barrier`, translated from glibc source
- `Semaphore` from nim's own sources
- `RwMonitor` (also known as `RwLock`) from [blog post](https://medium.com/adamedelwiess/operating-system-6-thread-part-2-reader-writer-problem-spurious-wakeups-and-deadlocks-6e28ab161002)
- `Arc` pointer type, it's the same as fusion/smartptrs `SharedPtr`
- `Once` @xflywind's [patch](https://github.com/nim-lang/Nim/pull/16192) to the stdlib

Todo:
- A test file for each
- Documentation and examples

Missing:
`ConstPtr`, should it be added? 
Any kind of queue, for example rust provides a MPSC queue in its library. I have a Nim [port](https://github.com/planetis-m/nim-100days/blob/master/multithread/waitfree.nim) of a SPMC queue based on Chase-Lev algorithm. I think it's better to have separate modules for queues.