### PR TITLE
`[DOC|TEST]` `opt()`, KV documentation improvements, better errors message for sequence mismatch, #98

### DIFF
--- a/src/fusion/matching.nim
+++ b/src/fusion/matching.nim
@@ -42,8 +42,6 @@ const
     ## identifiers)
 
 
-const debugWIP = false
-
 template echov(arg: untyped, indent: int = 0): untyped {.used.} =
   {.noSideEffect.}:
     when debugWIP:
@@ -1648,12 +1646,13 @@ proc makeElemMatch(
       let ln = elem.decl.lineIInfo()
       if doRaise and not debugWIP:
         var str = newNimNode(nnkRStrLit)
-        str.strVal = "Match failure for pattern '" & patternStr.strVal() &
+        str.strVal = "Match failure for pattern '" &
+            patternStr.strVal().codeFmt() &
             "'. Item at index "
 
         failBreak = quote do:
           {.line: `ln`.}:
-            raise MatchError(msg: `str` & $(`posid` - 1) & " failed")
+            raise MatchError(msg: `str` & $(`posid`) & " failed")
 
       var varset = newStmtList()
       if elem.bindVar.getSome(bindv):

--- a/src/fusion/matching.nim
+++ b/src/fusion/matching.nim
@@ -5,17 +5,6 @@ import std/[
 
 export options
 
-runnableExamples:
-  {.experimental: "caseStmtMacros".}
-
-  case [(1, 3), (3, 4)]:
-    of [(1, @a), _]:
-      echo a
-
-    else:
-      echo "Match failed"
-
-
 ## .. include:: matching.rst
 
 const

--- a/src/fusion/matching.nim
+++ b/src/fusion/matching.nim
@@ -2462,12 +2462,14 @@ proc matchImpl(n: NimNode): NimNode =
       else:
         discard
 
+  if matchcase.len() == 1 and
+     matchcase[0].kind == nnkElse:
+    matchcase.insert(
+      0, nnkElifBranch.newTree(newLit(false), newEmptyNode()))
+
   let head = n[0]
   var mixinList = newStmtList nnkMixinStmt.newTree(
-    mixidents.deduplicate.mapIt(
-      ident it
-    )
-  )
+    mixidents.deduplicate.mapIt(ident it))
 
   if mixidents.len == 0:
     mixinList = newEmptyNode()

--- a/src/fusion/matching.nim
+++ b/src/fusion/matching.nim
@@ -41,6 +41,7 @@ const
     ## Set of all token-like nodes (primitive type literals or
     ## identifiers)
 
+const debugWip = false
 
 template echov(arg: untyped, indent: int = 0): untyped {.used.} =
   {.noSideEffect.}:

--- a/tests/tmatching.nim
+++ b/tests/tmatching.nim
@@ -3008,3 +3008,19 @@ suite "Tests":
 
       else:
         testFail()
+
+  multitest "Assuming v2 as":
+    macro asssuming_v1(arg: untyped): untyped =
+      arg.assertMatch:
+
+        BracketExpr[@head, @typeParam] |
+        Command[@head, Bracket[@typeParam]] |
+        (@head is Ident())
+
+    macro assumingV2(arg, body: untyped): untyped =
+      arg.assertMatch:
+        Infix[(strVal: "as"), @expr, @name is Ident()] |
+        (@name is Ident())
+
+    assumingV2 expr() as name:
+      echo 12

--- a/tests/tmatching.nim
+++ b/tests/tmatching.nim
@@ -808,6 +808,22 @@ suite "Matching":
     expect MatchError:
       exception()
 
+  multitest "Box reimplementation":
+    type
+      TypeKind = enum tkString, tkInt, tkFloat
+      VNType = object
+        case kind: TypeKind
+        of tkString: stringVal*: string
+        of tkInt: intVal*: int
+        of tkFloat: floatVal*: float
+
+    proc `-` (a, b: VNType): VNType =
+      case (a, b):
+        of ((intVal: @val1(a.kind == tkInt)),
+            (intVal: @val2(b.kind == tkInt))):
+
+          return VNType(intVal: val1 - val2, kind: tkInt)
+
   multitest "Decision matrix":
     proc test1(str, arg: string): bool = str == arg
     proc test2(str, arg: string): bool = str == arg
@@ -1297,7 +1313,8 @@ suite "Matching":
       [(1 | 2)] := [3]
       testFail("[(1 | 2)] := [3]")
     except MatchError:
-      doAssert "pattern '(1 | 2)'" in getCurrentExceptionMsg()
+      doAssert "(1 | 2)" in getCurrentExceptionMsg(),
+        getCurrentExceptionMsg()
 
 
     1 := 1

--- a/tests/tmatching.nim
+++ b/tests/tmatching.nim
@@ -103,6 +103,20 @@ suite "Issue tests":
       of ZKind.Z1(o1: @i):
         doAssert i == 1
 
+  test "Compiler crashes when else match NimNode #98":
+    # https://github.com/nim-lang/fusion/issues/98
+    #
+    # Compiler crash was caused by depleted case - single `else` branch for
+    # case generated `IfStmt[Else[StmtList[]]]` node that is not valid.
+    # This caused compiler crash due to lack of bound check somewhere in
+    # the compiler body, I'm not sure what exactly.
+    macro m() =
+      case newLit(0):
+        else:
+          discard
+
+    m()
+
 suite "Matching":
   test "Pattern parser tests":
     macro main(): untyped =


### PR DESCRIPTION
Document difference between ``Some()/None()`` and ``opt``.